### PR TITLE
Escape control characters in path output (terminal escape injection)

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -24,6 +24,29 @@ fn ansi_style_for_path(lscolors: &LsColors, path: &Path) -> ansi_term::Style {
         .unwrap_or_default()
 }
 
+/// Neutralize control characters in a path before it is printed to the
+/// terminal. Path strings come from untrusted input (e.g. `find . | as-tree`),
+/// and on Unix a filename may contain any byte except `/` and NUL -- including
+/// ESC. Printing those raw lets a crafted filename inject terminal escape
+/// sequences (color/output spoofing, OSC title or clipboard writes, carriage
+/// return line rewrites). Control characters are rendered as visible escapes
+/// (e.g. ESC -> `\u{1b}`); printable text, including non-ASCII Unicode, is left
+/// untouched.
+fn escape_control(s: &str) -> String {
+    if !s.chars().any(char::is_control) {
+        return s.to_string();
+    }
+    let mut out = String::with_capacity(s.len());
+    for c in s.chars() {
+        if c.is_control() {
+            out.extend(c.escape_default());
+        } else {
+            out.push(c);
+        }
+    }
+    out
+}
+
 impl PathTrie {
     fn contains_singleton_dir(&self) -> bool {
         self.trie.len() == 1 && !self.trie.iter().next().unwrap().1.trie.is_empty()
@@ -58,10 +81,10 @@ impl PathTrie {
             let contains_singleton_dir = it.contains_singleton_dir();
 
             let painted = match full_path {
-                false => style.paint(path.to_string_lossy()),
+                false => style.paint(escape_control(&path.to_string_lossy())),
                 true => match contains_singleton_dir && !join_with_parent {
-                    false => style.paint(current_path.to_string_lossy()),
-                    true => style.paint(""),
+                    false => style.paint(escape_control(&current_path.to_string_lossy())),
+                    true => style.paint(String::new()),
                 },
             };
 
@@ -178,4 +201,28 @@ fn main() -> io::Result<()> {
     trie.print(&lscolors, options.full_path);
 
     io::Result::Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::escape_control;
+
+    #[test]
+    fn leaves_printable_text_untouched() {
+        assert_eq!(escape_control("normal.txt"), "normal.txt");
+        // Non-ASCII printable characters must survive unchanged.
+        assert_eq!(escape_control("café/ñoño/中文/🦀"), "café/ñoño/中文/🦀");
+        // The lossy UTF-8 replacement character is printable, not control.
+        assert_eq!(escape_control("a\u{fffd}b"), "a\u{fffd}b");
+    }
+
+    #[test]
+    fn escapes_control_characters() {
+        // No raw control byte may appear in the output.
+        assert_eq!(escape_control("\u{1b}[31mred"), "\\u{1b}[31mred"); // ESC
+        assert_eq!(escape_control("a\u{7}b"), "a\\u{7}b"); // BEL
+        assert_eq!(escape_control("REAL\rFAKE"), "REAL\\rFAKE"); // CR
+        assert_eq!(escape_control("x\u{7f}y"), "x\\u{7f}y"); // DEL
+        assert!(!escape_control("\u{1b}]0;title\u{7}").contains('\u{1b}'));
+    }
 }

--- a/test/security/escape_injection.sh
+++ b/test/security/escape_injection.sh
@@ -15,9 +15,9 @@
 # control byte in the output came straight from the input path. Each test
 # asserts the SECURE behavior (control bytes neutralized).
 #
-# STATUS: OPEN. These tests are EXPECTED TO FAIL until path output escapes
-# non-printable bytes (mirroring `ls -q`). This script is the red->green
-# acceptance test for that fix and should land together with it.
+# RESOLVED by escaping control characters in path output before printing
+# (src/main.rs: escape_control). This script is the acceptance test for that
+# fix and lands together with it; it must stay green.
 #
 # Usage:
 #   ./test/security/escape_injection.sh

--- a/test/security/escape_injection.sh
+++ b/test/security/escape_injection.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+#
+# Security test: terminal escape-sequence injection.
+#
+# src/main.rs prints input paths to the terminal with no sanitization, so any
+# control bytes in a path reach the terminal raw. The tool's headline use case
+# is `find . | as-tree`, and on Unix a filename may contain any byte except `/`
+# and NUL -- including ESC. A crafted filename can therefore:
+#   B1  inject ANSI SGR codes to spoof/recolor output;
+#   B2  inject an OSC sequence to set the window title, or on terminals that
+#       honor OSC 52, write to the clipboard;
+#   B3  inject a carriage return to redraw the line and hide the real path.
+#
+# All cases use `--color never`, so the tool emits NO escapes of its own; any
+# control byte in the output came straight from the input path. Each test
+# asserts the SECURE behavior (control bytes neutralized).
+#
+# STATUS: OPEN. These tests are EXPECTED TO FAIL until path output escapes
+# non-printable bytes (mirroring `ls -q`). This script is the red->green
+# acceptance test for that fix and should land together with it.
+#
+# Usage:
+#   ./test/security/escape_injection.sh
+#   AS_TREE_BIN=/path/to/as-tree ./test/security/escape_injection.sh
+#
+# Exit status: 0 if injection is neutralized, 1 if still exploitable.
+
+set -uo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+BIN="${AS_TREE_BIN:-}"
+if [ -z "$BIN" ]; then
+  if command -v cargo >/dev/null 2>&1; then
+    echo "Building as-tree (cargo build)..."
+    ( cd "$REPO_ROOT" && cargo build --quiet ) || { echo "ERROR: cargo build failed" >&2; exit 2; }
+    BIN="$REPO_ROOT/target/debug/as-tree"
+  fi
+fi
+[ -n "$BIN" ] && [ -x "$BIN" ] || { echo "ERROR: as-tree binary not found; set AS_TREE_BIN." >&2; exit 2; }
+echo "Testing binary: $BIN"
+echo
+
+_g() { printf '\033[32m%s\033[0m' "$1"; }
+_r() { printf '\033[31m%s\033[0m' "$1"; }
+nfail=0
+pass() { printf '  [%s] %s\n' "$(_g PASS)" "$1"; }
+fail() { nfail=$((nfail + 1)); printf '  [%s] %s\n' "$(_r FAIL)" "$1"; [ $# -ge 2 ] && printf '         -> %s\n' "$2"; }
+
+# Render control bytes visibly (ESC -> ^[, BEL -> ^G, CR -> ^M) and search.
+# `cat -v` is portable across GNU and BSD/macOS.
+contains_marker() { cat -v "$1" | grep -q "$2"; }
+
+echo "Terminal escape-sequence injection (src/main.rs)"
+
+# B1: ANSI SGR (color) codes embedded in a path -> output spoofing.
+printf 'safe/\033[31mLOOKS-RED\033[0m/leaf\n' | "$BIN" --color never >"$WORK/b1.out" 2>/dev/null
+if contains_marker "$WORK/b1.out" '\^\['; then
+  fail "B1 ANSI SGR escape in a path is neutralized" "raw ESC reached stdout -- output spoofing possible"
+else
+  pass "B1 ANSI SGR escape in a path is neutralized"
+fi
+
+# B2: OSC sequence (set window title / OSC 52 clipboard write) + BEL terminator.
+printf 'safe/\033]0;PWNED-TITLE\007/leaf\n' | "$BIN" --color never >"$WORK/b2.out" 2>/dev/null
+if contains_marker "$WORK/b2.out" '\^\[' || contains_marker "$WORK/b2.out" '\^G'; then
+  fail "B2 OSC title/clipboard sequence is neutralized" "raw ESC/BEL reached stdout -- title spoof / clipboard write possible"
+else
+  pass "B2 OSC title/clipboard sequence is neutralized"
+fi
+
+# B3: carriage return mid-path -> redraw the line to hide the real path.
+printf 'REAL-PATH\rFAKE-PATH/leaf\n' | "$BIN" --color never >"$WORK/b3.out" 2>/dev/null
+if contains_marker "$WORK/b3.out" '\^M'; then
+  fail "B3 carriage-return in a path is neutralized" "raw CR reached stdout -- line-overwrite spoofing possible"
+else
+  pass "B3 carriage-return in a path is neutralized"
+fi
+
+echo
+if [ "$nfail" -ne 0 ]; then
+  echo "$(_r VULNERABLE): $nfail/3 injection test(s) failing -- escape injection is NOT resolved."
+  echo "(Expected until path output is escaped.)"
+  exit 1
+fi
+echo "$(_g OK): escape injection resolved."
+exit 0


### PR DESCRIPTION
Hello,

While reading the code I noticed a security problem in the way as-tree print the paths.

as-tree write the input paths directly to the terminal, without any sanitisation. On Unix a filename can contain almost any byte (only `/` and NUL are not allowed), and the main use case is `find . | as-tree`. So when an attacker control a filename, he can put terminal escape sequences inside the name and as-tree print them raw to the terminal. For example this allow:

- ANSI SGR codes → spoof or recolor the output, hide lines
- OSC sequence → change the window title, or on terminal that support OSC 52, write to the clipboard
- carriage return → redraw the line to hide the real path

It is the same class of problem why `ls` escape non-printable characters by default (`ls -q`).

Small demonstration (I send the output to `cat -v` so the control bytes become visible):

before:
```
└── ^[]0;HACKED^G^[[31mevil^[[0m
```
after:
```
└── \u{1b}]0;HACKED\u{7}\u{1b}[31mevil\u{1b}[0m
```

The fix add a function `escape_control` in `src/main.rs` and apply it to every path string before painting. Control characters (C0/C1 and DEL) are render as visible escape like `\u{1b}`, but printable text — including non-ASCII Unicode like café, 中文, 🦀 — stay exactly the same. So for normal input the output is byte-for-byte identical to before: I check this by diffing the patched binary against the master binary on all fixtures and on `find` output, and there is zero difference.

I make the escaping always on, not only when stdout is a tty. The reason is that the attack also work when you do `as-tree > file` and later `cat file`, so a tty-only check is not enough in my opinion. But if you prefer the `ls` behaviour (escape only on tty, or use `?` instead of `\u{...}`), tell me and I change it.

Tests:
- `test/security/escape_injection.sh` reproduce the 3 cases and now pass
- unit tests cover the `escape_control` contract (`cargo test`)
- existing fixtures still pass, no change

I keep this separate from my other PR (the argument-panic fix) so each one is small and easy to review.

Thank you.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
