### PR TITLE
Add -L <n> option to limit the tree depth (like tree -L)

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -29,9 +29,14 @@ impl PathTrie {
         self.trie.len() == 1 && !self.trie.iter().next().unwrap().1.trie.is_empty()
     }
 
-    pub fn insert(&mut self, path: &Path) {
+    // Insert a path, keeping at most `max_level` components from the top.
+    // `None` inserts the whole path (unlimited depth).
+    pub fn insert(&mut self, path: &Path, max_level: Option<usize>) {
         let mut cur = self;
-        for comp in path.iter() {
+        for (depth, comp) in path.iter().enumerate() {
+            if matches!(max_level, Some(max) if depth >= max) {
+                break;
+            }
             cur = cur
                 .trie
                 .entry(PathBuf::from(comp))
@@ -136,11 +141,11 @@ impl PathTrie {
     }
 }
 
-fn drain_input_to_path_trie<T: BufRead>(input: &mut T) -> PathTrie {
+fn drain_input_to_path_trie<T: BufRead>(input: &mut T, max_level: Option<usize>) -> PathTrie {
     let mut trie = PathTrie::default();
 
     for path_buf in input.lines().filter_map(Result::ok).map(PathBuf::from) {
-        trie.insert(&path_buf)
+        trie.insert(&path_buf, max_level)
     }
 
     trie
@@ -154,12 +159,12 @@ fn main() -> io::Result<()> {
             if atty::is(atty::Stream::Stdin) {
                 eprintln!("Warning: reading from stdin, which is a tty.");
             }
-            drain_input_to_path_trie(&mut io::stdin().lock())
+            drain_input_to_path_trie(&mut io::stdin().lock(), options.max_level)
         }
         Some(filename) => {
             let file = File::open(filename)?;
             let mut reader = BufReader::new(file);
-            drain_input_to_path_trie(&mut reader)
+            drain_input_to_path_trie(&mut reader, options.max_level)
         }
     };
 
@@ -178,4 +183,36 @@ fn main() -> io::Result<()> {
     trie.print(&lscolors, options.full_path);
 
     io::Result::Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::PathTrie;
+    use std::path::PathBuf;
+
+    // Length of the longest chain of nodes = number of path components kept.
+    fn levels(trie: &PathTrie) -> usize {
+        trie.trie.values().map(|c| 1 + levels(c)).max().unwrap_or(0)
+    }
+
+    #[test]
+    fn insert_unlimited_keeps_all_components() {
+        let mut trie = PathTrie::default();
+        trie.insert(&PathBuf::from("a/b/c/d"), None);
+        assert_eq!(levels(&trie), 4);
+    }
+
+    #[test]
+    fn insert_truncates_to_max_level() {
+        let mut trie = PathTrie::default();
+        trie.insert(&PathBuf::from("a/b/c/d"), Some(2));
+        assert_eq!(levels(&trie), 2);
+    }
+
+    #[test]
+    fn max_level_larger_than_depth_is_unlimited() {
+        let mut trie = PathTrie::default();
+        trie.insert(&PathBuf::from("a/b/c/d"), Some(99));
+        assert_eq!(levels(&trie), 4);
+    }
 }

--- a/src/options.rs
+++ b/src/options.rs
@@ -35,6 +35,9 @@ pub struct Options {
     pub filename: Option<String>,
     pub colorize: Colorize,
     pub full_path: bool,
+    // Maximum tree depth to print, counted in path components from the top.
+    // None means unlimited.
+    pub max_level: Option<usize>,
 }
 
 const USAGE: &str = "\
@@ -50,6 +53,7 @@ Options:
   --color (always|auto|never)
                     Whether to colorize the output [default: auto]
   -f                Prints the full path prefix for each file.
+  -L <level>        Descend only <level> levels deep (must be > 0)
   -h, --help        Print this help message
   -v, --version     Print the version and exit
 
@@ -99,6 +103,18 @@ pub fn parse_options_or_die() -> Options {
                 }
             } else {
                 die("-> Unrecognized option:", &arg);
+            }
+            continue;
+        }
+
+        if arg == "-L" {
+            match argv.next() {
+                Some(level) => match level.parse::<usize>() {
+                    Ok(n) if n > 0 => options.max_level = Some(n),
+                    Ok(_) => die("Invalid level, must be greater than 0:", &level),
+                    Err(_) => die("Invalid level for -L:", &level),
+                },
+                None => die("Missing value for -L:", &arg),
             }
             continue;
         }

--- a/test/cli/level/run.sh
+++ b/test/cli/level/run.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# Fixed, deterministic input (piped, not `find`) so the golden output is stable
+# across machines. Covers the depth limit at, below, and at/above the real depth.
+input='docs/guide.md
+src/bin/main.rs
+src/lib/a.rs
+src/lib/b.rs'
+
+echo ----- -L 1 -----
+printf '%s\n' "$input" | src/as_tree -L 1 --color never
+
+echo ----- -L 2 -----
+printf '%s\n' "$input" | src/as_tree -L 2 --color never
+
+echo ----- -L 3 -----
+printf '%s\n' "$input" | src/as_tree -L 3 --color never
+
+# Collapse boundary: truncation turns a collapsed chain into separate lines.
+echo ----- -L 2 collapse boundary -----
+printf 'a/b/c\na/b/d\n' | src/as_tree -L 2 --color never

--- a/test/cli/level/run.sh.exp
+++ b/test/cli/level/run.sh.exp
@@ -1,0 +1,24 @@
+----- -L 1 -----
+.
+├── docs
+└── src
+----- -L 2 -----
+.
+├── docs
+│   └── guide.md
+└── src
+    ├── bin
+    └── lib
+----- -L 3 -----
+.
+├── docs
+│   └── guide.md
+└── src
+    ├── bin
+    │   └── main.rs
+    └── lib
+        ├── a.rs
+        └── b.rs
+----- -L 2 collapse boundary -----
+a
+└── b


### PR DESCRIPTION
Hello,

This PR add a new option `-L <n>`, that works like `tree -L`. It limit how deep the tree is printed. `<n>` must be an integer bigger than 0.

```
find . | as-tree -L 2
```

How it work: I truncate every input path to its first `<n>` components before inserting it into the trie, so the existing print and collapse logic stay exactly the same. When `-L` is not given, the depth is unlimited like before.

Small example, for this input:
```
docs/guide.md
src/bin/main.rs
src/lib/a.rs
src/lib/b.rs
```

`-L 1`:
```
.
├── docs
└── src
```

`-L 2`:
```
.
├── docs
│   └── guide.md
└── src
    ├── bin
    └── lib
```

One detail about the directory collapsing: as-tree join a single-dir chain like `a/b/c` into one line. When the limit cut such a chain, the tail become a leaf and the collapse does not happen at the boundary, so for `a/b/c` + `a/b/d` with `-L 2` you get:
```
a
└── b
```
instead of `a/b`. In my opinion this is fine — it is even a bit closer to `tree -L 2` — but I add a test for it so the behaviour is documented.

Validation: `-L 0`, a non-integer, a negative number, or `-L` without a value are all rejected with exit 1 and a message.

Tests:
- new CLI test `test/cli/level` for `-L 1/2/3` and the collapse boundary (deterministic input, piped, not `find`, so the golden output is stable)
- unit tests for the depth-limited insert (`cargo test`)
- existing fixtures are not changed, because the feature is opt-in

The change is small and only touch `src/options.rs` and `src/main.rs`. Please tell me if you prefer another name or another behaviour (for example, to count a collapsed line as one level instead of one component).

Thank you.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
