### PR TITLE
Fix Bazel toolchain fetch (checksum drift + repo rename)

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -7,8 +7,10 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 http_archive(
     name = "com_grail_bazel_toolchain",
     url = "https://github.com/grailbio/bazel-toolchain/archive/f2d1ba2c9d713b2aa6e7063f6d11dd3d64aa402a.zip",
-    sha256 = "0246482b21a04667825c655d3b4f8f796d842817b2e11f536bbfed5673cbfd97",
-    strip_prefix = "bazel-toolchain-f2d1ba2c9d713b2aa6e7063f6d11dd3d64aa402a",
+    sha256 = "f03728e32a893abc7b41a283c8943cd10a6082687aa5079b56e9f7e43010fdcc",
+    # grailbio/bazel-toolchain was renamed to toolchains_llvm, so the archive's
+    # top-level directory (strip_prefix) changed accordingly.
+    strip_prefix = "toolchains_llvm-f2d1ba2c9d713b2aa6e7063f6d11dd3d64aa402a",
 )
 
 load("@com_grail_bazel_toolchain//toolchain:deps.bzl", "bazel_toolchain_dependencies")


### PR DESCRIPTION
Hello,

The Bazel CI is broken right now: `bazel test //test` stops immediately with `0 packages loaded`, because the `com_grail_bazel_toolchain` archive can not be fetched anymore. There are two reasons, both outside of the code:

1. GitHub changed how it generate the auto source archive, so the `sha256` of the pinned commit drifted (`0246482b…` is now `f03728e…`). Bazel refuses the download because the checksum does not match.
2. `grailbio/bazel-toolchain` was renamed to `toolchains_llvm`, so the archive top-level directory changed too, and the old `strip_prefix` (`bazel-toolchain-…`) is not found in the archive anymore.

This PR updates both the `sha256` and the `strip_prefix`. I verified the new checksum by downloading the archive myself (it also matches what the CI runner reports). With the two changes the toolchain fetches again and Bazel goes on to the build / analysis phase.

The download URL is not changed — GitHub still redirects the old `grailbio/bazel-toolchain` URL to the new name, so the pin stays on the same commit.

It is a small infra-only change (one file), it does not touch any code. Please tell me if you prefer to bump the toolchain to a newer version instead.

Thank you.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
