### PR TITLE
Add crates.io publish metadata to Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,13 @@ name = "as-tree"
 version = "0.12.0"
 authors = ["Jake Zimmerman <zimmerman.jake@gmail.com>"]
 edition = "2018"
+description = "Print a list of paths as a tree of paths."
+license = "BlueOak-1.0.0"
+repository = "https://github.com/jez/as-tree"
+homepage = "https://github.com/jez/as-tree"
+readme = "README.md"
+keywords = ["tree", "cli", "find", "paths", "filesystem"]
+categories = ["command-line-utilities"]
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
Hello,

`as-tree` is not on crates.io yet, and I think the main reason is that `Cargo.toml` is missing the metadata that crates.io requires to publish — `description` and `license` are mandatory and `cargo publish` refuses without them.

This PR adds them, so publishing becomes a single `cargo publish`:

- `description`, and `license = "BlueOak-1.0.0"` (the SPDX id for the Blue Oak Model License 1.0.0 already in `LICENSE.md`)
- `repository`, `homepage`, `readme`
- `keywords` and `categories` (`command-line-utilities`)

No code change, only the manifest. I checked it with `cargo publish --dry-run` and it packages and verifies with no error.

One note: the dry-run package currently includes 61 files (~863 KiB), because it also picks up the Bazel files and `third_party/`. If you want a leaner crate, an `include = [...]` (or `exclude = [...]`) in `[package]` would trim it — tell me and I can add it, but I left it out to keep this PR minimal.

I did not touch the version. Publishing is of course yours to do.

Thank you.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
